### PR TITLE
Update imports so creds.js file matches instructions from documentation

### DIFF
--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -1,5 +1,5 @@
 import Medusa from "@medusajs/medusa-js";
-import creds from '../../creds.template';
+import creds from '../../creds';
 
 const BACKEND_URL = creds?.medusa_backend_url || "http://localhost:9000";
 

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -2,7 +2,7 @@
  * This is a singleton to ensure we only instantiate Stripe once.
  */
 import { loadStripe } from "@stripe/stripe-js";
-import creds from '../../creds.template';
+import creds from '../../creds';
 
 let stripePromise;
 


### PR DESCRIPTION
`stripe.js` and `client.js` reference `creds.template.js` but documentation says to rename `creds.template.js` to `creds.js`. Changed the imports to match `creds.js` per the documentation. 