### PR TITLE
Fixed missing import for retrieveAllProducts function

### DIFF
--- a/src/routes/checkout/informationStep.svelte
+++ b/src/routes/checkout/informationStep.svelte
@@ -3,7 +3,7 @@
   import * as Yup from "yup";
   import { addCartInfo, medusaCartState } from "../../state/cartStore";
   import { checkoutStore } from "../../state/checkoutStore";
-
+  import { retrieveAllProducts } from '../../state/productStore'
   let informationLoader = true;
   let cart;
   let currentCheckoutState;


### PR DESCRIPTION
Added the missing `import` from the `productStore` to the `informationStep.svelte` file. 